### PR TITLE
Correcting_conversion_formulas

### DIFF
--- a/adafruit_htu31d.py
+++ b/adafruit_htu31d.py
@@ -134,10 +134,10 @@ class HTU31D:
         # decode data into human values:
         # convert bytes into 16-bit signed integer
         # convert the LSB value to a human value according to the datasheet
-        temperature = -45.0 + 175.0 * temperature / 65535.0
+        temperature = -40.0 + 165.0 * temperature / 65535.0
 
         # repeat above steps for humidity data
-        humidity = -6.0 + 125.0 * humidity / 65535.0
+        humidity = 100 * humidity / 65535.0
         humidity = max(min(humidity, 100), 0)
 
         return (temperature, humidity)


### PR DESCRIPTION
Correct the conversion formulas for temperature and humidity:
1.  Source: https://www.amsys-sensor.com/downloads/data/HTU31D-AMSYS-datasheet.pdf
2. The Arduino Library has the right formulas: See:
https://github.com/adafruit/Adafruit_HTU31D/blob/2515b754dbe436b80faa6ffd4d670eae1a48913a/Adafruit_HTU31D.cpp#L177
https://github.com/adafruit/Adafruit_HTU31D/blob/2515b754dbe436b80faa6ffd4d670eae1a48913a/Adafruit_HTU31D.cpp#L194

Formulas used are for HTU21D-F sensor.

Tested on 
```python
Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit Feather RP2040 with rp2040
```
with an Adafruit HTU31D Sensor