### PR TITLE
Adding temp rh resolution properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,10 @@ Usage Example
 .. code-block:: python
 
     import time
-    import busio
     import board
     import adafruit_htu31d
 
-    i2c = busio.I2C(board.SCL, board.SDA)
+    i2c = board.I2C()  # uses board.SCL and board.SDA
     htu = adafruit_htu31d.HTU31D(i2c)
     print("Found HTU31D with serial number", hex(htu.serial_number))
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,12 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/htu31d_simpletest.py
     :caption: examples/htu31d_simpletest.py
     :linenos:
+
+Setting Resolution Example
+--------------------------
+
+Show how to setup Relative Humidity and Temperature Sensor Resolutions
+
+.. literalinclude:: ../examples/htu31d_setting_resolutions.py
+    :caption: examples/htu31d_setting_resolutions.py
+    :linenos:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ Table of Contents
 .. toctree::
     :caption: Related Products
 
-    Adafruit HTU31D breakout <https://www.adafruit.com/product/4832>
+    Adafruit HTU31 Temperature & Humidity Sensor Breakout Board <https://www.adafruit.com/product/4832>
 
 .. toctree::
     :caption: Other Links

--- a/examples/htu31d_setting_resolutions.py
+++ b/examples/htu31d_setting_resolutions.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 Jose David M.
+#
+# SPDX-License-Identifier: MIT
+
+import board
+import adafruit_htu31d
+
+
+# import htu31d_setting_resolutions
+i2c = board.I2C()
+htu = adafruit_htu31d.HTU31D(i2c)
+
+
+print("Temperature Resolution: ", htu.temp_resolution)
+print("Humidity Resolution: ", htu.humidity_resolution)
+
+
+# Setting the temperature resolution.
+# Possible values are "0.040", "0.025", "0.016" and "0.012"
+htu.temp_resolution = "0.016"
+
+# Setting the Relative Humidity resolution.
+# Possible values are "0.020%", "0.014%", "0.010%" and "0.007%"
+htu.humidity_resolution = "0.007%"
+
+
+# Printing the New Values
+print("Temperature Resolution: ", htu.temp_resolution)
+print("Humidity Resolution: ", htu.humidity_resolution)

--- a/examples/htu31d_simpletest.py
+++ b/examples/htu31d_simpletest.py
@@ -3,11 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 import time
-import busio
 import board
 import adafruit_htu31d
 
-i2c = busio.I2C(board.SCL, board.SDA)
+i2c = board.I2C()  # uses board.SCL and board.SDA
 htu = adafruit_htu31d.HTU31D(i2c)
 print("Found HTU31D with serial number", hex(htu.serial_number))
 


### PR DESCRIPTION
## Changes
1. Add temperature and relative humidity resolution attributes.
2. New example to show how to set this up
3. Modification of the documentation to have the same standard as other libraries

Testing
You could use the example for testing 

This was tested using
```python
Adafruit CircuitPython 6.2.0 on 2021-04-05; Adafruit Feather RP2040 with rp2040
```
with an Adafruit HTU31D sensor